### PR TITLE
Added the ability to define custom middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ The consuming application must include the following dependencies
 ### Project Structure
 The consuming application should have the following directory structure and files. This structure is [configurable](#options).
 * images/
+* server/
+  * server.js
 * src/
   * index.html
   * main.ts
@@ -282,6 +284,28 @@ Default: `[]`
 
 Specify vendor dependencies for test.
 
+### .gulpConnectMiddlewareApps
+
+Type: `Array<any>`
+Default: `[]`
+
+Provides a way to add one or more custom middleware apps to be loaded by gulp-connect in the serve:production and serve:development tasks (see: https://github.com/avevlad/gulp-connect#optionsmiddleware).
+
+For example:
+
+```
+var app = require('express').express();
+
+app.get('/hello', function(req, res) {
+    res.send('Hello World!');
+});
+
+ngGulp(gulp, {
+    ...
+    gulpConnectMiddlewareApps: [app]
+});
+```
+
 ## Testing
 ### Unit tests
 Execute a single run of the unit test suite by running `gulp test` using PhantomJS. `gulp test --chrome` will run the 
@@ -299,3 +323,21 @@ To enable running tests on file changes, set the `.autoWatch` option to true. *N
 
 ### E2E tests
 Coming soon
+
+## Custom Middleware
+
+In addition to using the `gulpConnectMiddlewareApps` configuration option, you can also have custom middleware apps loaded automatically by exporting a variable in the file: server/server.js.  ng-gulp automatically takes whatever is exported by this file, and adds it to the `gulpConnectMiddlewareApps` array when running the serve:production and serve:development tasks.
+
+Example server/server.js file:
+
+```
+var express = require('express');
+var app = express();
+
+app.get('/hello', function(req, res) {
+    res.send('Hello World!');
+});
+
+module.exports = app;
+```
+

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ var path = require('path');
 var webpack = require('webpack');
 var webpackStream = require('webpack-stream');
 var webpackMerge = require('webpack-merge');
+var fs = require('fs');
 
 
 var cwd = process.cwd();
@@ -29,6 +30,7 @@ var defaults = {
     debugTests: false,
     devServer: true,
     devServerPort: 8080,
+    gulpConnectMiddlewareApps: [],
     directories: {
         nodeModules: path.resolve(cwd, 'node_modules'),
         output: path.resolve(cwd, 'dist'),
@@ -301,9 +303,17 @@ function registerTasks(gulp, config) {
             .pipe(gulp.dest(config.directories.output));
     });
 
-    gulp.task('serve:development', function() {
+    gulp.task('add-custom-middleware', function() {
+        if (fs.existsSync(path.resolve(cwd, 'server/server.js'))) {
+            var customMiddleware = require(path.resolve(cwd, 'server/server.js'));
+            config.gulpConnectMiddlewareApps.push(customMiddleware);
+        }
+    });
+
+    gulp.task('serve:development', ['add-custom-middleware'], function() {
         var defaults = {
             livereload: true,
+            middleware: function() { return config.gulpConnectMiddlewareApps; },
             port: config.devServerPort,
             root: [ config.directories.output ]
         };
@@ -314,10 +324,14 @@ function registerTasks(gulp, config) {
         gulpConnect.server(options);
     });
 
-    gulp.task('serve:production', function() {
+    gulp.task('serve:production', ['add-custom-middleware'], function() {
+        if (config.productionServerGzip) {
+            config.gulpConnectMiddlewareApps.push(connectGzip.gzip());
+        }
+
         var defaults = {
             livereload: false,
-            middleware: function() { return config.productionServerGzip ? [ connectGzip.gzip() ] : []; },
+            middleware: function() { return config.gulpConnectMiddlewareApps; },
             port: config.productionServerPort,
             root: [ config.directories.output ]
         };

--- a/index.js
+++ b/index.js
@@ -303,14 +303,14 @@ function registerTasks(gulp, config) {
             .pipe(gulp.dest(config.directories.output));
     });
 
-    gulp.task('add-custom-middleware', function() {
+    gulp.task('serve:middleware', function() {
         if (fs.existsSync(path.resolve(cwd, 'server/server.js'))) {
             var customMiddleware = require(path.resolve(cwd, 'server/server.js'));
             config.gulpConnectMiddlewareApps.push(customMiddleware);
         }
     });
 
-    gulp.task('serve:development', ['add-custom-middleware'], function() {
+    gulp.task('serve:development', ['serve:middleware'], function() {
         var defaults = {
             livereload: true,
             middleware: function() { return config.gulpConnectMiddlewareApps; },
@@ -324,7 +324,7 @@ function registerTasks(gulp, config) {
         gulpConnect.server(options);
     });
 
-    gulp.task('serve:production', ['add-custom-middleware'], function() {
+    gulp.task('serve:production', ['serve:middleware'], function() {
         if (config.productionServerGzip) {
             config.gulpConnectMiddlewareApps.push(connectGzip.gzip());
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng-gulp",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Build configuration and development environment for Angular 1 applications using Typescript and Sass.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Added the ability to define custom middleware for the serve:production and serve:development tasks.

Users of ng-gulp can now add the file: server/server.js to their projects, and define handlers for HTTP calls, which can be handy for defining mock REST APIs.

An example of defining custom middleware in server/server.js is as follows:

var express = require('express');
var app = express();

app.get('/hello', function(req, res) {
    res.send('Hello from the new and improved mock middleware app!');
});

module.exports = app;